### PR TITLE
Fix for windows, closes #3

### DIFF
--- a/runner.js
+++ b/runner.js
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env node
 ":" //# why? http://sambal.org/?p=1014 ; exec /usr/bin/env node --harmony "$0" "$@"
 
 'use strict';


### PR DESCRIPTION
So the issue here is that I think npm does special parsing for the file that is supposed to be linked globally, and because it sees #!/bin/sh it thinks that it's only supported on linux, so the .bat file it generates actually looks for sh.exe instead of node.exe which of course is why it's failing. This doesn't work with esnext-generation (which has the same issue) because it does actually need --harmony passed to the node exe.
