### PR TITLE
Clarifying mission statement.

### DIFF
--- a/global-scope-and-shadowing/problem.md
+++ b/global-scope-and-shadowing/problem.md
@@ -105,9 +105,10 @@ nesting, or long functions.
 
 # Your Mission
 
-Starting with your solution from the previous lesson, assign a value to `quux`
-inside `foo()` (don't use `var` or `let`). The value should be different to the
-value assigned when defining `quux` inside `zip()`.
+Starting with your solution from the previous lesson, assign a value to the global variable
+`quux` inside `foo()` (don't use `var` or `let`). Create a shadow variable in of `quux`
+inside `zip()`. The value in the global variable `quux` has to be different than the
+value of `quux` inside `zip()`.
 
 Once complete, execute `$ADVENTURE_COMMAND verify <your-file.js>` to verify your
 solution.


### PR DESCRIPTION
The mission statement didn't not specify that the variable in `zip` should be shadowing the variable in `foo()`. Also changing `should` to `has to`.
