### PR TITLE
closure lesson fix for returning on the same line as zip() declaration

### DIFF
--- a/exercises/closures/index.js
+++ b/exercises/closures/index.js
@@ -15,11 +15,19 @@ module.exports = {
 
       scopeAsAscii = asciiScope(code);
 
-      t.equal(
-        scopeAsAscii,
-        ['(global)','\tfoo()','\t- var bar','\t- quux = ?','\treturn zip','\t\tzip()','\t\t- var quux', '\t\t- bar = ?'].join('\n'),
-        'The structure is correct'
-      );
+      if (scopeAsAscii.match(/return/)){
+        t.equal(
+          scopeAsAscii,
+          ['(global)','\tfoo()','\t- var bar','\t- quux = ?','\treturn zip','\t\tzip()','\t\t- var quux', '\t\t- bar = ?'].join('\n'),
+          'The structure is correct'
+        );
+      } else {
+        t.equal(
+          scopeAsAscii,
+          ['(global)','\tfoo()','\t- var bar','\t- quux = ?','\t\tzip()','\t\t- var quux', '\t\t- bar = ?'].join('\n'),
+          'The structure is correct'
+        );
+      }
 
       t.end();
 


### PR DESCRIPTION
### The closure lesson as it stands can incorrectly fail.

It occurs if the student has their return statement on the same line as their zip() function declaration.

**This fails:**

```
function foo() {
  var bar;
  quux = 1;

  return function zip() {    
    var quux = 0;
    bar = true;
  };
}
```

**This passes:**

```
function foo() {
  var bar;
  quux = 1;

  function zip() {    
    var quux = 0;
    bar = true;
  };
  return zip;
}
```

By doing a regex match on scopeAsAscii for the string "return" you can accommodate both potential solutions.

Please let me know if you have any questions.
